### PR TITLE
Replace Icinga with Icinga 2 and adapt URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Complex infrastructure software
 - [Opsview](https://www.opsview.com/products/opsview-atom) - Based on Nagios 4, Opsview Core is ideal for small IT and test environments.
 - [Centreon](http://www.centreon.com) - IT infrastructure and application monitoring for service performance.
 - [Naemon](http://www.naemon.org/) - Network monitoring tool based on the Nagios 4 core with performance enhancements and new features.
-- [Icinga](https://www.icinga.org/) - Fork of Nagios.
+- [Icinga 2](https://www.icinga.com/) - A Nagios like monitoring system, rewritten and expanded.
 - [openITCOCKPIT](https://openitcockpit.io/) - Powerful open-source monitoring tool built upon Naemon or Nagios, featuring seamless integration with Grafana, an array of comprehensive reports, and visualizations.
 
 Dashboards


### PR DESCRIPTION
Icinga (1) (which indeed was a Nagios fork) has been deprecated now for quite some time.
The successor (Icinga 2) is still very much alive and works one similar principles but was changed in some quite significant ways.

I also changed the URL, since the main one to be used is the `.com` one (although I still have to tell someone that the redirect should be fixed).