### PR TITLE
Add dish

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Databases
 ## Network
 
 - [Cacti](http://www.cacti.net) - Web-based network monitoring and graphing tool.
+- [dish](https://github.com/thevxn/dish) -  A lightweight monitoring service that efficiently checks socket connections and can be configured remotely. 
 - [Observium](http://www.observium.org/) - SNMP monitoring for servers and networking devices. Runs on linux.
 - [LibreNMS](https://github.com/librenms/librenms/) - Fork of Observium.
 - [Fluere](https://github.com/SkuldNorniern/fluere) - Versatile network interface monitoring and analysis tool, capable of capturing network packets in pcap format, NetFlow data. supports lua based plugins


### PR DESCRIPTION
This PR should add the dish monitoring service: a tiny configurable CLI tool, that is used to periodically check HTTP/S endpoints and TCP ports.