### PR TITLE
Add SSL Certificate Monitor - open-source SSL expiry monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Uptime
 - [elmah.io](https://elmah.io/features/uptime-monitoring/) - Uptime monitoring combined with application error logging
 - [StatusList.app](https://statuslist.app) - Uptime monitoring with debug details and hosted status page in one dashboard
 - [Sematext Synthetics](https://sematext.com/synthetic-monitoring) - Website uptime, API, and SSL certificate monitoring.  Includes status pages and scriptable multi-page user transaction monitoring, etc.
+- [SSL Certificate Monitor](https://github.com/brancogao/ssl-certificate-monitor) - Open-source SSL/TLS certificate expiry monitoring tool with web UI and REST API. Checks certificate validity and days until expiration.
 - [Uptime Kuma](https://github.com/louislam/uptime-kuma) - An easy-to-use self-hosted monitoring tool.
 - [Phare](https://phare.io/products/uptime) - Free 100k monitoring events per months, 30s intervals, unlimited users, incident management, and sleek status pages.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.


### PR DESCRIPTION
## Description
Added [SSL Certificate Monitor](https://github.com/brancogao/ssl-certificate-monitor) - an open-source tool for monitoring SSL/TLS certificate expiration.

## Features
- Check SSL/TLS certificate validity and expiration dates
- Web UI for easy monitoring
- REST API for integration
- Configurable alert thresholds
- Free hosted version available
- Open-source (MIT license)

## Demo
https://ssl-certificate-monitor.autocompany.workers.dev

This complements the existing commercial SSL monitoring tools with an open-source alternative.