### PR TITLE
Add PageGuard - free all-in-one website health scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Uptime
 - [Matomo](https://matomo.org/) - Take back control with Matomo – a powerful web analytics platform that gives you 100% data ownership.
 - [Heap Analytics](https://heap.io/) - Easy event tracking without coding
 - [Screpy](https://screpy.com) - Screpy is a web analyzer and monitoring tool. Its powered by Google Lighthouse.
+- [PageGuard](https://pageguard.qiudeqiu.workers.dev) - Free all-in-one website health scanner powered by Lighthouse. Monitors performance, SEO, accessibility, and best practices with AI-generated action plans and a free REST API.
 - [Shynet](https://github.com/milesmcc/shynet) - Modern, privacy-friendly, and cookie-free web analytics.
 
 ## API Analytics

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Uptime
 - [Matomo](https://matomo.org/) - Take back control with Matomo – a powerful web analytics platform that gives you 100% data ownership.
 - [Heap Analytics](https://heap.io/) - Easy event tracking without coding
 - [Screpy](https://screpy.com) - Screpy is a web analyzer and monitoring tool. Its powered by Google Lighthouse.
-- [PageGuard](https://pageguard.qiudeqiu.workers.dev) - Free all-in-one website health scanner powered by Lighthouse. Monitors performance, SEO, accessibility, and best practices with AI-generated action plans and a free REST API.
+- [PageGuard](https://pageguard.org) - Free all-in-one website health scanner powered by Lighthouse. Monitors performance, SEO, accessibility, and best practices with AI-generated action plans and a free REST API.
 - [Shynet](https://github.com/milesmcc/shynet) - Modern, privacy-friendly, and cookie-free web analytics.
 
 ## API Analytics


### PR DESCRIPTION
## What is PageGuard?

[PageGuard](https://pageguard.qiudeqiu.workers.dev) is a free all-in-one website health scanner powered by Lighthouse, similar to Screpy already in this list.

**What it monitors:**
- **Performance** — Core Web Vitals, LCP, FID, CLS
- **SEO** — meta tags, structured data, crawlability
- **Accessibility** — WCAG 2.1 compliance
- **Best Practices** — security headers, HTTPS, modern standards

**Plus:**
- AI-generated action plans (natural language recommendations)
- Free CORS-enabled REST API for programmatic access
- No signup required, results in ~30 seconds

## Why Web Analytics section?

PageGuard provides web health monitoring that belongs alongside tools like Screpy. It's free, requires no login, and gives developers a quick health check baseline for any URL.

**Live**: https://pageguard.qiudeqiu.workers.dev
**API**: https://pageguard.qiudeqiu.workers.dev/docs