### PR TITLE
Add API Status Aggregation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Uptime
 - [Screpy](https://screpy.com) - Screpy is a web analyzer and monitoring tool. Its powered by Google Lighthouse.
 - [Shynet](https://github.com/milesmcc/shynet) - Modern, privacy-friendly, and cookie-free web analytics.
 
+## API Status Aggregation
+
+- [API Status Check](https://apistatuscheck.com) - Real-time status dashboard for 160+ third-party APIs including AI platforms (OpenAI, Anthropic), cloud providers (AWS, Vercel), payments (Stripe, PayPal), and developer tools (GitHub, Supabase). Includes embeddable status badges.
+- [IncidentHub](https://incidenthub.cloud) - Status page aggregator for monitoring SaaS and cloud providers.
+- [StatusGator](https://statusgator.com) - Cloud service monitoring, aggregating status pages of cloud services into a single dashboard.
+
 ## API Analytics
 
 - [Apitally](https://apitally.io) - Analytics, request logging and monitoring for REST APIs with a focus on simplicity and data privacy.


### PR DESCRIPTION
## What this PR adds

A new **API Status Aggregation** section for tools that monitor third-party API and SaaS provider status pages.

### Why this section is needed

The list comprehensively covers infrastructure monitoring (Zabbix, Nagios, etc.), uptime monitoring (UptimeRobot, Checkly, etc.), and APM (DataDog, NewRelic, etc.) — but there's a gap for **third-party dependency monitoring**.

Modern applications rely heavily on external APIs (AI providers, payment processors, cloud services, etc.). When Stripe or OpenAI goes down, your infrastructure monitors show green — but your application is broken. These tools fill that visibility gap.

### Tools added

| Tool | Description |
|------|-------------|
| [API Status Check](https://apistatuscheck.com) | Real-time status dashboard for 160+ third-party APIs (AI, cloud, payments, developer tools). Includes embeddable status badges. |
| [IncidentHub](https://incidenthub.cloud) | Status page aggregator for SaaS and cloud providers. |
| [StatusGator](https://statusgator.com) | Cloud service monitoring, aggregating status pages into a single dashboard. |

All three are actively maintained and serve different segments of the dependency monitoring use case.