### PR TITLE
Add Spork to monitoring tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Uptime
 - [Uptime Kuma](https://github.com/louislam/uptime-kuma) - An easy-to-use self-hosted monitoring tool.
 - [Phare](https://phare.io/products/uptime) - Free 100k monitoring events per months, 30s intervals, unlimited users, incident management, and sleek status pages.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.
+- [Spork](https://sporkops.com) - Uptime monitoring with built-in status pages, CLI, and Terraform provider. Multi-region consensus checks from $4/mo.
+
 
 ## APM
 *Application Performance monitoring*


### PR DESCRIPTION
Adding Spork to the Uptime monitoring subsection under Servers.

Spork is an uptime monitoring tool with built-in status pages, custom domains, a CLI, and a Terraform provider.

Website: https://sporkops.com
