### PR TITLE
Add Crontiq - Cron monitoring with auto JSON metric extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Uptime
 - [Uptime Kuma](https://github.com/louislam/uptime-kuma) - An easy-to-use self-hosted monitoring tool.
 - [Phare](https://phare.io/products/uptime) - Free 100k monitoring events per months, 30s intervals, unlimited users, incident management, and sleek status pages.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.
+- [Crontiq](https://crontiq.io) - Free cron job monitoring with automatic JSON metric extraction and zero-config anomaly detection. 20 monitors free forever.
 
 ## APM
 *Application Performance monitoring*


### PR DESCRIPTION
Hi! I'd like to add [Crontiq](https://crontiq.io) to this list.

**What it does:** Cron job monitoring (heartbeat/dead man's switch) with two unique features:
1. **Auto JSON metric extraction** — POST any JSON payload with your ping, Crontiq automatically extracts all numeric values and tracks them over time
2. **Zero-config anomaly detection** — Moving average + 2σ computed automatically, no thresholds to configure

**Free tier:** 20 monitors, unlimited pings, email alerts, public SVG badges

It's similar to Healthchecks.io and Cronitor but focuses on payload analysis rather than just heartbeat detection.

Website: https://crontiq.io