### PR TITLE
Add Oack to Uptime section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Uptime
 - [BlueWave Uptime](https://github.com/bluewave-labs/bluewave-uptime) - Open-source, self-hosted monitoring tool built with React.js, Node.js, and MongoDB, designed to track server uptime, response times, and incidents in real-time with beautiful visualizations.
 - [Freshping](https://www.freshworks.com/website-monitoring) - Free for 50 monitors, checked every 1 minutes, supports websocket monitoring
 - [Monitive](http://monitive.com) - Free for 1 service, checked every 10 minutes with unlimited email & twitter alerts
+- [Oack](https://oack.io) - HTTP monitoring with TCP kernel telemetry, 6-phase latency breakdown, Server-Timing header capture, Cloudflare CDN enrichment, and built-in incident management with on-call scheduling.
 - [Checkly](https://www.checklyhq.com/) - Code-first synthetic monitoring for modern DevOps. Monitor your APIs and apps at a fraction of the price of legacy providers. Powered by a Monitoring as Code workflow and Playwright.
 - [UptimeRobot](https://uptimerobot.com) - Free for 50 monitors, checked every 5 minutes
 - [UpTime.onl](https://uptime.onl) - Free for 10 URLs, checked every 5 minutes


### PR DESCRIPTION
Added [Oack](https://oack.io) to the Uptime monitoring section.

Oack is an HTTP monitoring service with deep network diagnostics — TCP kernel telemetry (RTT, retransmits, congestion window via TCP_INFO), 6-phase latency breakdown, automatic Server-Timing header capture, Cloudflare CDN log enrichment, and built-in incident management with on-call scheduling.