### PR TITLE
Add VisualSentinel to Uptime list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Uptime
 - [Uptime Kuma](https://github.com/louislam/uptime-kuma) - An easy-to-use self-hosted monitoring tool.
 - [Phare](https://phare.io/products/uptime) - Free 100k monitoring events per months, 30s intervals, unlimited users, incident management, and sleek status pages.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.
+- [VisualSentinel](https://visualsentinel.com) - Website monitoring with uptime, visual change detection (screenshot diff of the live site), SSL, DNS, performance, and content checks. Free tier for 3 monitors, checks from EU and US. Alerts via Slack, Discord, WhatsApp, Telegram, PagerDuty and webhooks.
 
 ## APM
 *Application Performance monitoring*


### PR DESCRIPTION
Adding VisualSentinel to the Uptime section. It's a website monitoring service with uptime, visual change detection (live screenshot diff), SSL, DNS, performance and content checks. Free tier for 3 monitors, checks from EU and US.

Not currently listed.