### PR TITLE
Add Voidly Check to API Status Aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Uptime
 - [API Status Check](https://apistatuscheck.com) - Real-time status dashboard for 160+ third-party APIs including AI platforms (OpenAI, Anthropic), cloud providers (AWS, Vercel), payments (Stripe, PayPal), and developer tools (GitHub, Supabase). Includes embeddable status badges.
 - [IncidentHub](https://incidenthub.cloud) - Status page aggregator for monitoring SaaS and cloud providers.
 - [StatusGator](https://statusgator.com) - Cloud service monitoring, aggregating status pages of cloud services into a single dashboard.
+- [Voidly Check](https://github.com/voidly-ai/voidly-check-action) - GitHub Action that verifies your services aren't blocked in target countries (Iran, China, Russia, etc.) using real OONI measurements. Backed by `api.voidly.ai` (19.6M samples).
 
 ## API Analytics
 


### PR DESCRIPTION
## What

Adds [Voidly Check](https://github.com/voidly-ai/voidly-check-action) to the API Status Aggregation section.

## Why this fits

Most status aggregators tell you whether the upstream service is up. Voidly Check tells you whether real users in censored countries (Iran, China, Russia, UAE, etc.) can reach you. Different failure mode, same operational concern. It's a GitHub Action so teams can wire it directly into CI as a release gate.

## Format

- Single-line entry following the section's existing style
- Added at the end of the section
- Real-world value highlighted: backed by 19.6M OONI samples via `api.voidly.ai`