### PR TITLE
Add DownStatus to API Status Aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Uptime
 ## API Status Aggregation
 
 - [API Status Check](https://apistatuscheck.com) - Real-time status dashboard for 160+ third-party APIs including AI platforms (OpenAI, Anthropic), cloud providers (AWS, Vercel), payments (Stripe, PayPal), and developer tools (GitHub, Supabase). Includes embeddable status badges.
+- [DownStatus](https://isitdownstatus.com) - Free JSON API providing real-time status for GitHub, AWS, Discord, Cloudflare, Stripe, and 90+ popular services.
 - [IncidentHub](https://incidenthub.cloud) - Status page aggregator for monitoring SaaS and cloud providers.
 - [StatusGator](https://statusgator.com) - Cloud service monitoring, aggregating status pages of cloud services into a single dashboard.
 


### PR DESCRIPTION
## What does this add?

Adds **[DownStatus](https://isitdownstatus.com)** to the **API Status Aggregation** section.

DownStatus is a free JSON API that returns real-time status for 90+ popular services including GitHub, AWS, Discord, Cloudflare, and Stripe — no API key required, HTTPS, CORS supported.

It fits naturally alongside API Status Check and IncidentHub in the API Status Aggregation section.