### PR TITLE
Add DevHelm to Uptime section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Uptime
 - [Uptime Kuma](https://github.com/louislam/uptime-kuma) - An easy-to-use self-hosted monitoring tool.
 - [Phare](https://phare.io/products/uptime) - Free 100k monitoring events per months, 30s intervals, unlimited users, incident management, and sleek status pages.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.
+- [DevHelm](https://devhelm.io) - Developer-first uptime monitoring (HTTP, DNS, TCP, ICMP, heartbeat) with dependency intelligence for 80+ providers, hosted status pages, and config-as-code. Free tier: 50 monitors.
 
 ## APM
 *Application Performance monitoring*


### PR DESCRIPTION
## What is DevHelm?

[DevHelm](https://devhelm.io) is a developer-first uptime monitoring platform that provides:

- **Multi-protocol monitoring** — HTTP, DNS, TCP, ICMP, and heartbeat checks
- **Dependency intelligence** — track the status of 80+ third-party providers your services depend on
- **Hosted status pages** — with custom domain support
- **Full developer surface** — CLI, Python SDK, JS/TS SDK, Terraform provider, and MCP server for AI agents
- **Config-as-code** — define monitors in `devhelm.yml`

**Free tier:** 50 monitors + status page

- Website: https://devhelm.io
- Docs: https://docs.devhelm.io
- GitHub: https://github.com/devhelmhq

## Why it belongs in the Uptime section

DevHelm is an uptime monitoring service similar to existing entries like BetterUptime, UptimeRobot, and Checkly, with the added focus on dependency intelligence and developer tooling.

## Changes

Added DevHelm entry to the bottom of the Uptime section, following the existing `- [Name](url) - Description` format.