### PR TITLE
Add groundcover to APM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Uptime
 - [BitDive](https://bitdive.io/) - APM for Java/Kotlin with distributed tracing, method-level profiling, and performance metrics.
 - [Middleware](https://middleware.io) - Middleware's APM helps you troubleshoot issues in real-time, optimize performance, improve user experience, and reduce downtime.
 - [PerfScope](https://github.com/sattyamjjain/perfscope) - Advanced Python performance profiler with decorator-based setup, call tree visualization, memory tracking, and multi-format report export.
+- [groundcover](https://www.groundcover.com/) - eBPF-based observability platform for Kubernetes with logs, metrics, traces, and APM; deployed inside the user's own cloud (BYOC).
 
 ## Web Analytics
 


### PR DESCRIPTION
Adds groundcover to the APM section.

groundcover is a commercial eBPF-based observability platform for Kubernetes — a single DaemonSet sensor captures logs, metrics, traces, and APM across the cluster. Same category as the existing APM entries Datadog, NewRelic, Middleware, and Last9. The BYOC architecture (data plane runs inside the customer's own cloud) is the differentiator vs the other SaaS APM vendors listed.

Appended to the end of the section per the maintainer's usual flow.

Disclosure: I work at groundcover.