### PR TITLE
Add Oh Dear to Uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Uptime
 - [Uptime Kuma](https://github.com/louislam/uptime-kuma) - An easy-to-use self-hosted monitoring tool.
 - [Phare](https://phare.io/products/uptime) - Free 100k monitoring events per months, 30s intervals, unlimited users, incident management, and sleek status pages.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.
+- [Oh Dear](https://ohdear.app) - Monitoring for uptime, performance, SSL certificates, broken links, and DNS, with hosted status pages
 
 ## APM
 *Application Performance monitoring*


### PR DESCRIPTION
Adds Oh Dear (https://ohdear.app) to the Uptime section. Oh Dear is a website monitoring SaaS covering uptime, performance, SSL certificates, broken links, DNS, scheduled tasks, and hosted status pages. It is not currently listed.