### PR TITLE
Add HomeLab Monitor to Dashboards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Dashboards
 - [Uchiwa](https://uchiwa.io) - Simple dashboard for the Sensu monitoring framework.
 - [Monit](http://mmonit.com/monit/#home) - Small Open Source utility for managing and monitoring Unix systems.
 - [Netdata](https://www.netdata.cloud/agent/) - Troubleshoot slowdowns and anomalies in your infrastructure with thousands of metrics, interactive visualizations, and insightful health alarms.
+- [HomeLab Monitor](https://github.com/SikamikanikoBG/homelab-monitor) - Self-hosted homelab dashboard in a single Docker container - per-container GPU/VRAM attribution, Docker health, systemd service status, and host vitals across multiple machines over SSH.
 
 Uptime
 


### PR DESCRIPTION
Adds HomeLab Monitor to the Dashboards section under Servers.

HomeLab Monitor is an open-source self-hosted dashboard that runs as a single Docker container. Its main feature is per-container GPU/VRAM attribution - it tells you which Docker container is holding the GPU, not just that the GPU is busy. Alongside that it shows Docker container health, systemd service status, host vitals (CPU/RAM/disk/temps), and watches multiple machines over SSH from one view. Useful for AI/homelab rigs running local LLMs. MIT license, Python.

Placement: after the Netdata entry (last in the Dashboards subsection), before the Uptime subsection header.
