### PR TITLE
Add Superhighway to Uptime section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Uptime
 - [Phare](https://phare.io/products/uptime) - Free 100k monitoring events per months, 30s intervals, unlimited users, incident management, and sleek status pages.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.
 - [FlareWarden](https://flarewarden.com) — Uptime, content, dependency, and SSL monitoring with multi-region verification and status pages. Free plan includes 15 monitors, 5-minute checks, and 90 days of history.
+- [Superhighway](https://superhighway.walls.sh) - Web API whose `/scrape` endpoint turns any URL into clean Markdown, useful for building your own content/page-change monitoring (e.g. competitor pricing, changelogs, pages without an RSS feed). See the [change-detection tutorial](https://superhighway.walls.sh/guides/web-change-detection-agent): scrape, SHA-256 hash comparison, LLM-summarize what changed, and schedule with cron or GitHub Actions. Free API key or pay-per-call.
   
 ## APM
 *Application Performance monitoring*


### PR DESCRIPTION
Adds Superhighway to the Uptime section as a building block for content/page-change monitoring.

Superhighway's `/scrape` endpoint turns any URL into clean Markdown (noise-free, so it hashes reliably), which makes it a useful primitive for rolling your own content-change monitoring — competitor pricing, changelogs, job boards, or any page without an RSS feed.

The entry also links a complete tutorial that covers: scraping a URL to Markdown, SHA-256 hash comparison to detect changes, LLM summarization of what changed, and scheduling with cron or a GitHub Actions workflow.

Free API key or pay-per-call. Format and section placement follow the existing Uptime entries.