### PR TITLE
Add Flowtriq to Network section

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Databases
 - [Smokeping](https://oss.oetiker.ch/smokeping/) - SmokePing is a deluxe latency measurement tool.
 - [LibreNMS](https://github.com/librenms/librenms/) - Fork of Observium.
 - [Fluere](https://github.com/SkuldNorniern/fluere) - Versatile network interface monitoring and analysis tool, capable of capturing network packets in pcap format, NetFlow data. supports lua based plugins
+- [Flowtriq](https://github.com/Flowtriq/flowtriq-pfsense-opnsense) - DDoS detection for firewalls and routers (pfSense, OPNsense, VyOS) via NetFlow/sFlow export. Detects volumetric floods, SYN floods, amplification attacks, and provides real-time alerting with automated mitigation.
 
 # License
 


### PR DESCRIPTION
Adds [Flowtriq](https://flowtriq.com) to the Network section.

Flowtriq is a DDoS detection platform with open-source integrations for firewalls and routers (pfSense, OPNsense, VyOS). It analyzes NetFlow/sFlow/IPFIX data to detect volumetric floods, SYN floods, DNS amplification, and other attack types. Supports real-time alerting and automated mitigation via BGP FlowSpec and RTBH.

- GitHub: https://github.com/Flowtriq/flowtriq-pfsense-opnsense
- Also: https://github.com/Flowtriq/flowtriq-vyos