### PR TITLE
Add sunwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Uptime
 - [Phare](https://phare.io/products/uptime) - Free 100k monitoring events per months, 30s intervals, unlimited users, incident management, and sleek status pages.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.
 - [FlareWarden](https://flarewarden.com) — Uptime, content, dependency, and SSL monitoring with multi-region verification and status pages. Free plan includes 15 monitors, 5-minute checks, and 90 days of history.
-  
+- [sunwatch](https://sunwatch.sunfamily.xyz) - Crypto-paid uptime monitoring for side projects. Pay per monitor with USDC on Base; webhook alerts on down/up state changes.
+
 ## APM
 *Application Performance monitoring*
 


### PR DESCRIPTION
Add sunwatch to the Uptime section. sunwatch is a minimal uptime monitor paid with USDC on Base, no accounts or KYC, with webhook alerts.