### PR TITLE
Add OpenChainBench to API Status Aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Uptime
 
 - [API Status Check](https://apistatuscheck.com) - Real-time status dashboard for 160+ third-party APIs including AI platforms (OpenAI, Anthropic), cloud providers (AWS, Vercel), payments (Stripe, PayPal), and developer tools (GitHub, Supabase). Includes embeddable status badges.
 - [IncidentHub](https://incidenthub.cloud) - Status page aggregator for monitoring SaaS and cloud providers.
+- [OpenChainBench](https://openchainbench.com) - Open live benchmarks of blockchain infrastructure APIs and RPC providers (latency p50/p90/p99, success rate, multi-region), built on a public Prometheus; all data CC-BY-4.0.
 - [StatusGator](https://statusgator.com) - Cloud service monitoring, aggregating status pages of cloud services into a single dashboard.
 
 ## API Analytics


### PR DESCRIPTION
Adds OpenChainBench — open, live benchmarks of blockchain infrastructure APIs and RPC providers. Latency percentiles (p50/p90/p99) + success rate, probed every 15s from 3 regions, all metrics served from a public Prometheus instance anyone can query. Harnesses are open source (MIT), data CC-BY-4.0.