### PR TITLE
Add ReqKey to API Analytics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Uptime
 
 - [Apitally](https://apitally.io) - Analytics, request logging and monitoring for REST APIs with a focus on simplicity and data privacy.
 - [BurnRate](https://getburnrate.io) - AI coding cost analytics CLI that tracks usage and spend across Claude Code, Cursor, Copilot, Windsurf, Aider, Cline, and Codex. Includes optimization rules and rate limit monitoring.
+- [ReqKey](https://www.reqkey.com) - API key authentication, usage credits, rate limiting, and request analytics for REST APIs via a single verify call. SDKs for Python, Node.js, Go, Rust, PHP, .NET, and Java, with a free tier of 100,000 requests per month.
 
 ## Bug Tracking
 


### PR DESCRIPTION
Adds [ReqKey](https://www.reqkey.com) to the **API Analytics** section.

ReqKey provides API key authentication, usage credits, rate limiting, and request analytics for REST APIs. Your middleware makes a single verify call per request — it is not a proxy or gateway in front of your API. Per-request logs capture status code, latency, and location, which is what places it alongside Apitally in this section.

- Free tier: 100,000 requests/month, no credit card
- SDKs: Python, Node.js, Go, Rust, PHP, .NET, Java
- Docs: https://www.reqkey.com/docs

Single-line addition, formatting matched to neighbouring entries.

Disclosure: I work on ReqKey.