### PR TITLE
Add Hyperping

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Uptime
 - [Phare](https://phare.io/products/uptime) - Free 100k monitoring events per months, 30s intervals, unlimited users, incident management, and sleek status pages.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.
 - [FlareWarden](https://flarewarden.com) — Uptime, content, dependency, and SSL monitoring with multi-region verification and status pages. Free plan includes 15 monitors, 5-minute checks, and 90 days of history.
+- [Hyperping](https://hyperping.com) - Uptime, API, cron, and server monitoring from 18 locations, with Playwright browser checks, on-call scheduling, and hosted status pages.
   
 ## APM
 *Application Performance monitoring*


### PR DESCRIPTION
Adds [Hyperping](https://hyperping.com) to the Servers section, next to the other hosted uptime services.

Uptime, API, cron and server monitoring checked from 18 locations, with Playwright browser checks, on-call scheduling with escalation policies, and public or private status pages.